### PR TITLE
MAJOR UPDATE! eslint - disable unused rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "test": "exit 0",
-    "lint": "yarn eslint packages/**/*.{js,jsx,ts,tsx}",
+    "lint": "yarn eslint \"packages/**/*.{js,jsx,ts,tsx}\"",
     "lint:teamcity": "yarn lint --format ./node_modules/eslint-teamcity/index.js",
     "lint:fix": "yarn lint --fix",
     "compile": "yarn boltify run build",

--- a/packages/eslint-plugin-xcritical/package.json
+++ b/packages/eslint-plugin-xcritical/package.json
@@ -46,14 +46,11 @@
 		"babel-eslint": "10.1.0",
 		"eslint": "6.8.0",
 		"eslint-config-airbnb": "18.1.0",
-		"eslint-config-prettier": "6.11.0",
 		"eslint-plugin-babel": "5.3.0",
 		"eslint-plugin-class-methods-use-this-regexp": ">= 0.1.0",
 		"eslint-plugin-import": "^2.20.2",
 		"eslint-plugin-jsx-a11y": "6.2.3",
-		"eslint-plugin-prettier": "3.1.3",
 		"eslint-plugin-react": "7.19.0",
-		"eslint-plugin-react-hooks": "4.0.0",
-		"prettier": "2.0.5"
+		"eslint-plugin-react-hooks": "4.0.0"
 	}
 }

--- a/packages/eslint-plugin-xcritical/src/overrides/typescript.js
+++ b/packages/eslint-plugin-xcritical/src/overrides/typescript.js
@@ -1,6 +1,7 @@
-const typescriptImportPluginSettings = require('eslint-plugin-import/config/typescript').settings;
+const { settings: typescriptImportPluginSettings } = require('eslint-plugin-import/config/typescript');
 
-const rules = require('../rules/typescript');
+const rulesTS = require('../rules/typescript');
+const rulesJS = require('../rules/common');
 
 
 module.exports = {
@@ -14,6 +15,9 @@ module.exports = {
     },
   },
   plugins: ['@typescript-eslint'],
-  rules: rules,
+  rules: {
+    ...rulesJS,
+    ...rulesTS,
+  },
   settings: typescriptImportPluginSettings,
 };

--- a/packages/eslint-plugin-xcritical/src/rules/common.js
+++ b/packages/eslint-plugin-xcritical/src/rules/common.js
@@ -22,6 +22,18 @@ const commonRules = {
     },
   ],
   'prefer-const': 'warn',
+  'prefer-destructuring': ['error', {
+    VariableDeclarator: {
+      array: false,
+      object: true,
+    },
+    AssignmentExpression: {
+      array: true,
+      object: false,
+    },
+  }, {
+    enforceForRenamedProperties: true,
+  }],
   'react/jsx-curly-spacing': [
     'error',
     {

--- a/packages/eslint-plugin-xcritical/src/rules/typescript.js
+++ b/packages/eslint-plugin-xcritical/src/rules/typescript.js
@@ -1,4 +1,4 @@
-const typescriptEslintRecommendedRules = require('@typescript-eslint/eslint-plugin/dist/configs/all.json').rules;
+const { rules: typescriptEslintRecommendedRules } = require('@typescript-eslint/eslint-plugin/dist/configs/all.json');
 
 
 const typescriptRules = {
@@ -15,6 +15,29 @@ const typescriptRules = {
   '@typescript-eslint/no-type-alias': 'off',
   '@typescript-eslint/no-explicit-any': 'warn',
   '@typescript-eslint/quotes': ['error', 'single'],
-  '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true, allowTypedFunctionExpressions: true, allowHigherOrderFunctions: true }],
+  '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
+  '@typescript-eslint/no-unnecessary-condition': ['error', { ignoreRhs: true }],
+  '@typescript-eslint/no-inferrable-types': 0, // this is a temporary solution due to problems in TS (see: https://github.com/microsoft/TypeScript/pull/30593)
+  '@typescript-eslint/restrict-template-expressions': 0,
+  '@typescript-eslint/space-before-function-paren': 0,
+  '@typescript-eslint/explicit-function-return-type': [1, {
+    allowExpressions: true,
+    allowTypedFunctionExpressions: true,
+    allowHigherOrderFunctions: true,
+  }],
+  'import/extensions': ['error', 'never', { svg: 'always' }],
+  'import/no-extraneous-dependencies': 0,
+  '@typescript-eslint/require-await': 0,
+  '@typescript-eslint/promise-function-async': ['warn'],
+  '@typescript-eslint/no-non-null-assertion': ['warn'],
+  '@typescript-eslint/prefer-readonly-parameter-types': 0,
+  '@typescript-eslint/no-unsafe-assignment': 0,
+  '@typescript-eslint/no-unsafe-call': 0,
+  '@typescript-eslint/no-unsafe-return': 0,
+  '@typescript-eslint/no-unsafe-member-access': 0,
+  '@typescript-eslint/explicit-module-boundary-types': ['warn'],
+  '@typescript-eslint/init-declarations': 0,
+  '@typescript-eslint/default-param-last': ['warn'],
+  '@typescript-eslint/no-non-null-asserted-optional-chain': ['warn'],
 };
 module.exports = typescriptRules;

--- a/packages/gulpify/gulp/component-package.js
+++ b/packages/gulpify/gulp/component-package.js
@@ -11,7 +11,7 @@ const Vinyl = require('vinyl');
  */
 function getComponentPackage(file) {
   const dirname = path.dirname(file.path);
-  const componentName = path.parse(file.path).name;
+  const { name: componentName } = path.parse(file.path);
   const isIndexFileExist = fs.existsSync(path.join(dirname, 'index.js'));
   return JSON.stringify({
     main: isIndexFileExist ? 'index.js' : `${componentName}.js`,


### PR DESCRIPTION
- Disabled some TS rules after updating a component
- Added a few new rules: 
   `@typescript-eslint/member-ordering` 
   `@typescript-eslint/no-invalid-void-type`
- Update rule prefer-destructuring
